### PR TITLE
Load of FRITZ!OS version via direct request.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-fritzconnection>=1.12.2
 pyfritzhome>=0.6.8
 requests>=2.31.0
 selenium==4.10.0


### PR DESCRIPTION
Loads the FRITZ!OS version via direct HTTP request & response JSON parsing instead of using Fritzconnection. This removes an external dependency and also reduces the number of logins/interactions to the device which could cause stress on older, less performant models and also reduces the number of parallel sessions.